### PR TITLE
Provide default template

### DIFF
--- a/plugin.coffee
+++ b/plugin.coffee
@@ -7,6 +7,38 @@ module.exports = (env, callback) ->
   options = env.config.jade or {}
   options.pretty ?= true
 
+
+
+  class JadeStringTemplate
+
+    constructor: (@fn) ->
+
+    render: (locals, callback) ->
+      try
+        callback null, new Buffer @fn(locals)
+      catch error
+        callback error
+
+  DefaultTemplate = new JadeStringTemplate jade.compile "!=page.html", options
+
+  templateView = (env, locals, contents, templates, callback) ->
+    ### Content view that expects content to have a @template instance var that
+        matches a template in *templates*. Calls *callback* with output of template
+        or null if @template is set to 'none'. ###
+
+    if @template is 'none'
+      template =  DefaultTemplate
+
+    else
+      template = templates[@template]
+      if not template?
+        callback new Error "page '#{ @filename }' specifies unknown template '#{ @template }'"
+        return
+
+    ctx = {page: this}
+    env.utils.extend ctx, locals
+    template.render ctx, callback
+
   class JadePlugin extends env.plugins.Page
 
     constructor: (@filepath, @metadata, @tpl) ->
@@ -37,5 +69,6 @@ module.exports = (env, callback) ->
         callback null, new JadePlugin(filepath, result.metadata, tpl)
     ], callback
 
+  env.registerView 'template', templateView
   env.registerContentPlugin 'pages', '**/*.jade', JadePlugin
   callback() # tell the plugin manager we are done


### PR DESCRIPTION
Provides a basic default template `"!=page.html`, which allows a developer to avoid putting front matter in their jade files at all.
