### PR TITLE
Added hyphens for metadata block to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Create a `.jade` file in your content directory. Wintersmith would usually ignor
 
 To provide Wintersmith with metadata, use the following as a formatting example.
 
+	---
 	title = 'Title'
 	subtitle = 'Subtitle'
 	date = '2013/10/12'
 	teaser = 'Here is a sample teaser.'
 	template = 'standard.jade'
-
+	---
+	
 	p Content here.


### PR DESCRIPTION
Initially I couldn't get this plugin working as I worked off the example in the README file. I noticed fairly quickly that the example project contains the three hyphens indication the metadata block. I think it would be helpful to include these in the README example to prevent future users from making my mistake.