### PR TITLE
switched from jade to jade-legacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "jade"
   ],
   "dependencies": {
+    "async": "0.2.x",
     "coffee-script": ">=1.3",
-    "jade": "~0.31.1",
-    "async": "0.2.x"
+    "jade-legacy": "~1.11.1"
   },
   "devDependencies": {},
   "optionalDependencies": {},

--- a/plugin.coffee
+++ b/plugin.coffee
@@ -1,6 +1,6 @@
 fs = require 'fs'
 async = require 'async'
-jade = require 'jade'
+jade = require 'jade-legacy'
 
 module.exports = (env, callback) ->
 


### PR DESCRIPTION
This eliminates the warning about jade changing to pug, and uses jade-legacy like wintersmith does.

See [this pull request](https://github.com/jnordberg/wintersmith/pull/308) for more details.